### PR TITLE
fix: syntax and code comments errors

### DIFF
--- a/src/connection/statement_iterator.rs
+++ b/src/connection/statement_iterator.rs
@@ -111,8 +111,8 @@ impl<'stmt, 'query> Iterator for StatementIterator<'stmt, 'query> {
                 // by checking if our Rc owns the data or not
                 if let Some(last_row_ref) = Rc::get_mut(last_row) {
                     // We own the statement, there is no other reference here.
-                    // This means we don't need to copy out values from the sqlite provided
-                    // datastructures for now
+                    // This means we don't need to copy out values from the SQLite-provided
+                    // data structures for now
                     // We don't need to use the runtime borrowing system of the RefCell here
                     // as we have a mutable reference, so all of this below is checked at compile time
                     if let PrivateSqliteRow::Direct(ref mut stmt) = last_row_ref.get_mut() {

--- a/src/ffi/constants.rs
+++ b/src/ffi/constants.rs
@@ -13,7 +13,7 @@ use wasm_bindgen::prelude::*;
 ///         v if *ffi::SQLITE_DONE == v {
 ///             /* SQLITE_DONE */
 ///         },
-///         v if *ffi:SQLITE_ROW == v {
+///         v if *ffi::SQLITE_ROW == v {
 ///             /* SQLITE_ROW */
 ///         }
 ///     }

--- a/tests/test/web.rs
+++ b/tests/test/web.rs
@@ -1,4 +1,4 @@
-//! General tests for migrations/diesel ORM/persistant databases
+//! General tests for migrations/diesel ORM/persistent databases
 use crate::common::prelude::*;
 use sqlite_web::dsl::RunQueryDsl;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Corrected spelling of "persistent" in test comments
	- Updated comment casing and formatting in SQLite-related documentation
	- Improved syntax for module constant referencing in comments

These changes are purely documentation-related and do not impact the functionality of the code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->